### PR TITLE
Bumping up the version manually to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/samples-js-react",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* The repo had started with 0.0.1  but artifactory on promotion yielded 0.1.0
manually revving up to 1.0.0 to align with angular samples repo and to allow promote flow
to automatically bump up going forward.

RESOLVES: OKTA-112041
BACON: TEST