### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/samples-js-react",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The `package.json` version from #9 failed to update accordingly. Reverting to `1.3.0` for release.

See the original change to [`package.json`](https://github.com/okta/samples-js-react/pull/9/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2).