### PR TITLE
Fixing the "UnhandledPromiseRejectionWarning" while running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "test": "eslint -c .eslintrc.json --ext .js --ext .jsx okta-hosted-login/src/ custom-login/src/ && npm run test:e2e",
     "okta-hosted-login-server": "npm start --prefix okta-hosted-login/",
-    "test:okta-hosted-login": "protractor okta-oidc-tck/e2e-tests/okta-hosted-login/conf.js",
+    "test:okta-hosted-login": "export TEST_TYPE=implicit && protractor okta-oidc-tck/e2e-tests/okta-hosted-login/conf.js",
     "custom-login-server": "npm start --prefix custom-login/",
-    "test:custom-login": "protractor okta-oidc-tck/e2e-tests/custom-login/conf.js",
+    "test:custom-login": "export TEST_TYPE=implicit && protractor okta-oidc-tck/e2e-tests/custom-login/conf.js",
     "resource-server": "node samples-nodejs-express-4/resource-server/server.js",
-    "test:e2e": "cross-env TEST_TYPE=implicit && npm run get-oidc-tck && npm run test:okta-hosted-login && npm run test:custom-login",
+    "test:e2e": "export TEST_TYPE=implicit && npm run get-oidc-tck && npm run test:okta-hosted-login && npm run test:custom-login",
     "get-oidc-tck": "[ ! -d okta-oidc-tck/ ] && git clone https://github.com/okta/okta-oidc-tck.git || echo \"TCK already cloned\"",
     "pretest": "webdriver-manager update --gecko false",
     "postinstall": "npm run install-custom-login && npm run install-okta-hosted-login",
@@ -25,7 +25,6 @@
   "bugs": "https://github.com/okta/samples-js-react/issues",
   "homepage": "https://github.com/okta/samples-js-react",
   "devDependencies": {
-    "cross-env": "^5.1.1",
     "eslint": "^4.13.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
* Need to `export TEST_TYPE=implicit` to start the resource-server for each test
* `cross-env` doesn't set env var in the process started by the TCK. Hence removing it, as we don't support running tests on windows anyway