### PR TITLE
if the session is already deleted when logout is called redirect to l…

### DIFF
--- a/okta-hosted-login/src/Navbar.jsx
+++ b/okta-hosted-login/src/Navbar.jsx
@@ -37,7 +37,17 @@ export default withAuth(class Navbar extends Component {
   }
 
   async logout() {
-    this.props.auth.logout('/');
+    let loginRedirect = this.login
+    // Redirect to '/' after logout
+    //if session is active
+    this.props.auth.logout('/')
+    .then(function (out){
+      console.log("session is deleted");
+    })
+    .catch(function (error) {
+      //if session is inactive
+      loginRedirect();
+    })
   }
 
   render() {


### PR DESCRIPTION
…ogin page

This PR will solve this issue https://github.com/okta/samples-js-react/issues/25

If the session is already expired or deleted and you try to "logout" It will give an error. This promise catches the error and redirects back to login page
