### PR TITLE
use `window.location.origin` as base for redirect uri

### DIFF
--- a/custom-login/src/config.js
+++ b/custom-login/src/config.js
@@ -1,12 +1,14 @@
+/* global window */
 const CLIENT_ID = process.env.CLIENT_ID || '{clientId}';
 const ISSUER = process.env.ISSUER || 'https://{yourOktaDomain}.com/oauth2/default';
 const OKTA_TESTING_DISABLEHTTPSCHECK = process.env.OKTA_TESTING_DISABLEHTTPSCHECK || false;
+const REDIRECT_URI = `${window.location.origin}/implicit/callback`;
 
 export default {
   oidc: {
     clientId: CLIENT_ID,
     issuer: ISSUER,
-    redirectUri: 'http://localhost:8080/implicit/callback',
+    redirectUri: REDIRECT_URI,
     scopes: ['openid', 'profile', 'email'],
     pkce: true,
     disableHttpsCheck: OKTA_TESTING_DISABLEHTTPSCHECK,

--- a/okta-hosted-login/src/config.js
+++ b/okta-hosted-login/src/config.js
@@ -1,12 +1,14 @@
+/* global window */
 const CLIENT_ID = process.env.CLIENT_ID || '{clientId}';
 const ISSUER = process.env.ISSUER || 'https://{yourOktaDomain}.com/oauth2/default';
 const OKTA_TESTING_DISABLEHTTPSCHECK = process.env.OKTA_TESTING_DISABLEHTTPSCHECK || false;
+const REDIRECT_URI = `${window.location.origin}/implicit/callback`;
 
 export default {
   oidc: {
     clientId: CLIENT_ID,
     issuer: ISSUER,
-    redirectUri: 'http://localhost:8080/implicit/callback',
+    redirectUri: REDIRECT_URI,
     scopes: ['openid', 'profile', 'email'],
     pkce: true,
     disableHttpsCheck: OKTA_TESTING_DISABLEHTTPSCHECK,


### PR DESCRIPTION
This allows testing with `localhost` but also deployment to other locations or serving under different hostnames without changing or refactoring the source. (additional redirect uris will need to be configured with Okta admin console)