### PR TITLE
fix page header for custom login example

### DIFF
--- a/custom-login/src/Home.jsx
+++ b/custom-login/src/Home.jsx
@@ -53,7 +53,7 @@ const Home = () => {
   return (
     <div>
       <div>
-        <Header as="h1">PKCE Flow w/ Okta Hosted Login Page</Header>
+        <Header as="h1">PKCE Flow w/ Custom Login</Header>
 
         { authState.isAuthenticated && !userInfo
         && <div>Loading user information...</div>}


### PR DESCRIPTION
appropriately delineates `custom` vs `okta-hosted` for congruencys sake

went thru okta-hosted first, then custom, but this made me hesitate for a moment thinking I botched something.

perhaps such a change will help save others a moment of dissonance, even if only a moment