### PR TITLE
Extend custom onAuthRequired handler with modal dialog to ask user to re-authenticate

### DIFF
--- a/custom-login/package.json
+++ b/custom-login/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.0",
   "private": true,
   "dependencies": {
-    "@okta/okta-auth-js": "^5.6.0",
-    "@okta/okta-react": "^6.2.0",
+    "@okta/okta-auth-js": "^5.9.0",
+    "@okta/okta-react": "^6.3.0",
     "@okta/okta-signin-widget": "^5.12.2",
     "colors": "^1.4.0",
     "semantic-ui-css": "^2.4.1",

--- a/custom-login/src/App.jsx
+++ b/custom-login/src/App.jsx
@@ -42,7 +42,8 @@ const App = () => {
   };
 
   const customAuthHandler = async () => {
-    if (oktaAuth.authStateManager.getPreviousAuthState()?.isAuthenticated) {
+    const previousAuthState = oktaAuth.authStateManager.getPreviousAuthState();
+    if (!previousAuthState || !previousAuthState.isAuthenticated) {
       // App initialization stage
       triggerLogin();
     } else {

--- a/custom-login/src/App.jsx
+++ b/custom-login/src/App.jsx
@@ -22,26 +22,38 @@ import Messages from './Messages';
 import Navbar from './Navbar';
 import Profile from './Profile';
 import CorsErrorModal from './CorsErrorModal';
+import AuthRequiredModal from './AuthRequiredModal';
 
 const oktaAuth = new OktaAuth(config.oidc);
 
 const App = () => {
+  const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
+  const [authRequiredModalOpen, setAuthRequiredModalOpen] = React.useState(false);
+
   const history = useHistory(); // example from react-router
+
+  const triggerLogin = () => {
+    // Redirect to the /login page that has a CustomLoginComponent
+    history.push('/login');
+  };
 
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
 
-  const customAuthHandler = () => {
-    // Redirect to the /login page that has a CustomLoginComponent
-    history.push('/login');
+  const customAuthHandler = async () => {
+    if (oktaAuth.authStateManager.getPreviousAuthState()?.isAuthenticated) {
+      // App initialization stage
+      triggerLogin();
+    } else {
+      // Ask the user to trigger the login process during token autoRenew process
+      setAuthRequiredModalOpen(true);
+    }
   };
-
+  
   const onAuthResume = async () => {
     history.push('/login');
   };
-
-  const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
 
   return (
     <Security
@@ -51,6 +63,7 @@ const App = () => {
     >
       <Navbar {...{ setCorsErrorModalOpen }} />
       <CorsErrorModal {...{ corsErrorModalOpen, setCorsErrorModalOpen }} />
+      <AuthRequiredModal {...{ authRequiredModalOpen, setAuthRequiredModalOpen, triggerLogin }} />
       <Container text style={{ marginTop: '7em' }}>
         <Switch>
           <Route path="/" exact component={Home} />

--- a/custom-login/src/AuthRequiredModal.jsx
+++ b/custom-login/src/AuthRequiredModal.jsx
@@ -31,7 +31,7 @@ const AuthRequiredModal = ({ authRequiredModalOpen, setAuthRequiredModalOpen, tr
       closeOnDocumentClick={false}
       closeOnDimmerClick={false}
     >
-      <Modal.Header>Auth requried</Modal.Header>
+      <Modal.Header>Auth required</Modal.Header>
       <Modal.Content>
         <Modal.Description>
           <p>Do you want to re-authenticate?</p>

--- a/custom-login/src/AuthRequiredModal.jsx
+++ b/custom-login/src/AuthRequiredModal.jsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { Modal, Button } from 'semantic-ui-react';
+
+const AuthRequiredModal = ({ authRequiredModalOpen, setAuthRequiredModalOpen, triggerLogin }) => {
+  const closeModal = () => {
+    setAuthRequiredModalOpen(false);
+  };
+
+  const confirmModal = () => {
+    setAuthRequiredModalOpen(false);
+    triggerLogin();
+  };
+
+  return (
+    <Modal
+      onClose={closeModal}
+      onActionClick={confirmModal}
+      open={authRequiredModalOpen}
+      closeOnDocumentClick={false}
+      closeOnDimmerClick={false}
+    >
+      <Modal.Header>Auth requried</Modal.Header>
+      <Modal.Content>
+        <Modal.Description>
+          <p>Do you want to re-authenticate?</p>
+        </Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button onClick={closeModal}>
+          No
+        </Button>
+        <Button positive onClick={confirmModal}>
+          Yes
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+export default AuthRequiredModal;

--- a/okta-hosted-login/package.json
+++ b/okta-hosted-login/package.json
@@ -3,8 +3,8 @@
   "version": "0.3.0",
   "private": true,
   "dependencies": {
-    "@okta/okta-auth-js": "^5.6.0",
-    "@okta/okta-react": "^6.2.0",
+    "@okta/okta-auth-js": "^5.9.0",
+    "@okta/okta-react": "^6.3.0",
     "colors": "^1.4.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3",

--- a/okta-hosted-login/src/App.jsx
+++ b/okta-hosted-login/src/App.jsx
@@ -41,7 +41,8 @@ const App = () => {
   };
 
   const customAuthHandler = async () => {
-    if (!oktaAuth.authStateManager.getPreviousAuthState()?.isAuthenticated) {
+    const previousAuthState = oktaAuth.authStateManager.getPreviousAuthState();
+    if (!previousAuthState || !previousAuthState.isAuthenticated) {
       // App initialization stage
       await triggerLogin();
     } else {

--- a/okta-hosted-login/src/App.jsx
+++ b/okta-hosted-login/src/App.jsx
@@ -22,25 +22,43 @@ import Messages from './Messages';
 import Navbar from './Navbar';
 import Profile from './Profile';
 import CorsErrorModal from './CorsErrorModal';
+import AuthRequiredModal from './AuthRequiredModal';
 
 const oktaAuth = new OktaAuth(config.oidc);
 
 const App = () => {
+  const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
+  const [authRequiredModalOpen, setAuthRequiredModalOpen] = React.useState(false);
+
   const history = useHistory(); // example from react-router
+
+  const triggerLogin = async () => {
+    await oktaAuth.signInWithRedirect();
+  };
 
   const restoreOriginalUri = async (_oktaAuth, originalUri) => {
     history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
 
-  const [corsErrorModalOpen, setCorsErrorModalOpen] = React.useState(false);
+  const customAuthHandler = async () => {
+    if (!oktaAuth.authStateManager.getPreviousAuthState()?.isAuthenticated) {
+      // App initialization stage
+      await triggerLogin();
+    } else {
+      // Ask the user to trigger the login process during token autoRenew process
+      setAuthRequiredModalOpen(true);
+    }
+  };
 
   return (
     <Security
       oktaAuth={oktaAuth}
+      onAuthRequired={customAuthHandler}
       restoreOriginalUri={restoreOriginalUri}
     >
       <Navbar {...{ setCorsErrorModalOpen }} />
       <CorsErrorModal {...{ corsErrorModalOpen, setCorsErrorModalOpen }} />
+      <AuthRequiredModal {...{ authRequiredModalOpen, setAuthRequiredModalOpen, triggerLogin }} />
       <Container text style={{ marginTop: '7em' }}>
         <Switch>
           <Route path="/" exact component={Home} />

--- a/okta-hosted-login/src/AuthRequiredModal.jsx
+++ b/okta-hosted-login/src/AuthRequiredModal.jsx
@@ -31,7 +31,7 @@ const AuthRequiredModal = ({ authRequiredModalOpen, setAuthRequiredModalOpen, tr
       closeOnDocumentClick={false}
       closeOnDimmerClick={false}
     >
-      <Modal.Header>Auth requried</Modal.Header>
+      <Modal.Header>Auth required</Modal.Header>
       <Modal.Content>
         <Modal.Description>
           <p>Do you want to re-authenticate?</p>

--- a/okta-hosted-login/src/AuthRequiredModal.jsx
+++ b/okta-hosted-login/src/AuthRequiredModal.jsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { Modal, Button } from 'semantic-ui-react';
+
+const AuthRequiredModal = ({ authRequiredModalOpen, setAuthRequiredModalOpen, triggerLogin }) => {
+  const closeModal = () => {
+    setAuthRequiredModalOpen(false);
+  };
+
+  const confirmModal = () => {
+    setAuthRequiredModalOpen(false);
+    triggerLogin();
+  };
+
+  return (
+    <Modal
+      onClose={closeModal}
+      onActionClick={confirmModal}
+      open={authRequiredModalOpen}
+      closeOnDocumentClick={false}
+      closeOnDimmerClick={false}
+    >
+      <Modal.Header>Auth requried</Modal.Header>
+      <Modal.Content>
+        <Modal.Description>
+          <p>Do you want to re-authenticate?</p>
+        </Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button onClick={closeModal}>
+          No
+        </Button>
+        <Button positive onClick={confirmModal}>
+          Yes
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+export default AuthRequiredModal;

--- a/scripts/e2e-oie.sh
+++ b/scripts/e2e-oie.sh
@@ -16,8 +16,8 @@ export TEST_RESULT_FILE_DIR="${REPO}/build2/reports"
 
 export ORG_OIE_ENABLED=true # This flag ensures the TCK tests run OIE tests
 export USE_INTERACTION_CODE=true # This flag ensures that the self hosted widget uses interact code flow
-export ISSUER=https://oie-widget-tests.sigmanetcorp.us/oauth2/default
-export CLIENT_ID=0oa3nv55b0KjBuxEq0g7
+export ISSUER=https://oie-signin-widget.okta.com/oauth2/default
+export CLIENT_ID=0oa8lrg7ojTsbJgRQ696
 export USERNAME=george@acme.com
 export EMAIL_MFA_USERNAME=email-login@email.ghostinspector.com
 get_secret prod/okta-sdk-vars/password PASSWORD


### PR DESCRIPTION
Added custom `onAuthRequired ` callback to both `custom-login` and `okta-hosted-login` samples with logic:
- If no previousAuthState, it's app initialization phase -> redirect user to the login page
- Otherwise it's autoRenew process -> display modal dialog to ask the user to trigger the login process

This way we can break the auto login loop

Internal ref: [OKTA-445782](https://oktainc.atlassian.net/browse/OKTA-445782)

