### PR TITLE
Include link to original source of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Sample Applications for Okta
 
-This repository contains several sample applications that demonstrate various Okta use-cases in your React application.
+[This repository](https://github.com/okta/samples-js-react) contains several sample applications that demonstrate various Okta use-cases in your React application.
 
 Each sample makes use of the [Okta React Library][].
 


### PR DESCRIPTION
This repo is often used in examples, where it's copied wholesale or inserted via submodule into another repository. 

If a user wants to modify the JS app's actual source, rather than just the local copy, they will benefit from having the link.

I discovered this omission when reviewing an example repo that uses this app, https://github.com/noinarisak/okta-terraform-hub-spoke-oidc, and I had to go ask the author about where the React sample came from rather than just seeing it in the readme.