### PR TITLE
Change test environment file to correct name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once you have completed the form, you will be given a **client ID**. You will al
 
 The **issuer** is the URL of the authorization server that will perform authentication.  All Developer Accounts have a "default" authorization server.  The issuer is a combination of your Org URL (found in the upper right of the console home page) and `/oauth2/default`. For example, `https://dev-133337.okta.com/oauth2/default`.
 
-These values must exist as environment variables. They can be exported in the shell, or saved in a file named `testenv`, located in the same directory as this README. See [dotenv](https://www.npmjs.com/package/dotenv) for more details on this file format.
+These values must exist as environment variables. They can be exported in the shell, or saved in a file named `.testenv`, located in the same directory as this README. See [dotenv](https://www.npmjs.com/package/dotenv) for more details on this file format.
 
 ```ini
 ISSUER=https://yourOktaDomain.com/oauth2/default


### PR DESCRIPTION
The code is looking for `.testenv` but the README tells me to create a file called `testenv`.